### PR TITLE
Fixed crash on optimised x86 build.

### DIFF
--- a/tic_focus.cpp
+++ b/tic_focus.cpp
@@ -500,8 +500,6 @@ IPState FocusTic::MoveAbsFocuser(int targetTicks)
 	FocusAbsPosNP.s = IPS_BUSY;
 	IDSetNumber(&FocusAbsPosNP, NULL);
 
-	SetSpeed(2);
-        
     // set direction
 
     const char* direction;    
@@ -531,6 +529,4 @@ IPState FocusTic::MoveAbsFocuser(int targetTicks)
     return IPS_OK;
 }
 
-bool FocusTic::SetSpeed(int speed)
-{}
 

--- a/tic_focus.h
+++ b/tic_focus.h
@@ -60,7 +60,6 @@ class FocusTic : public INDI::Focuser
         virtual IPState MoveFocuser(FocusDirection dir, int speed, int duration);
         virtual IPState MoveAbsFocuser(int ticks);
         virtual IPState MoveRelFocuser(FocusDirection dir, int ticks);
-        virtual bool SetSpeed(int speed);
 };
 
 #endif


### PR DESCRIPTION
Non void virtual function must return a value, or it can crash on optimised x86 build. SetSpeed was such a function. As it was unused I have removed it.